### PR TITLE
Norwegian locales: fix order of the days of the week

### DIFF
--- a/locales/nb_NO
+++ b/locales/nb_NO
@@ -194,14 +194,14 @@ grouping                3;3
 END LC_NUMERIC
 
 LC_TIME
-abday       "ma.";"ti.";"on.";"to.";"fr.";"l<U00F8>.";"s<U00F8>."
-day         "mandag";/
+abday       "s<U00F8>.";"ma.";"ti.";"on.";"to.";"fr.";"l<U00F8>."
+day         "s<U00F8>ndag";/
+            "mandag";/
             "tirsdag";/
             "onsdag";/
             "torsdag";/
             "fredag";/
-            "l<U00F8>rdag";/
-            "s<U00F8>ndag"
+            "l<U00F8>rdag"
 abmon       "jan.";"feb.";/
             "mars";"april";/
             "mai";"juni";/

--- a/locales/nn_NO
+++ b/locales/nn_NO
@@ -194,14 +194,14 @@ grouping                3;3
 END LC_NUMERIC
 
 LC_TIME
-abday       "ma.";"ti.";"on.";"to.";"fr.";"l<U00F8>.";"su."
-day         "m<U00E5>ndag";/
+abday       "su.";"m<U00E5>.";"ti.";"on.";"to.";"fr.";"la."
+day         "sundag";/
+            "m<U00E5>ndag";/
             "tysdag";/
             "onsdag";/
             "torsdag";/
             "fredag";/
-            "laurdag ";/
-            "sundag"
+            "laurdag"
 abmon       "jan.";"feb.";/
             "mars";"april";/
             "mai";"juni";/


### PR DESCRIPTION
as reported:
"There is something wrong with the settings for Norwegian Bokmål (Nb) and Norwegian nynorsk (nn). Today in menu the day is starting on "tirsdag" in english: tuesday. It should be "mandag" in english: monday."
